### PR TITLE
Fix npm publish decision output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}
-      should-publish: ${{ steps.check.outputs.should-publish }}
+      should_publish: ${{ steps.check.outputs.should_publish }}
 
     steps:
       - name: Checkout the CI-tested revision
@@ -83,7 +83,7 @@ jobs:
 
   publish:
     needs: check-version
-    if: needs.check-version.outputs.should-publish == 'true'
+    if: needs.check-version.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -142,7 +142,7 @@ jobs:
       - publish
     if: >-
       needs.check-version.result == 'success' &&
-      needs.check-version.outputs.should-publish == 'true' &&
+      needs.check-version.outputs.should_publish == 'true' &&
       needs.publish.result == 'success'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The version-check step writes `should_publish`, but the job mapping read `should-publish`. This makes the downstream publish and release conditions see an empty value.

This consistently uses `should_publish` for the step output, job output, and downstream conditions.