### PR TITLE
Use reusable npm publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,11 @@ jobs:
 
       - name: Pack the plugin
         run: vp pack
+
+  publish:
+    needs: verify
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: write
+      id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Publish to npm
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  # Call this from CI after its required jobs succeed. npm Trusted Publishing
+  # must be configured with the caller filename, ci.yml, not this filename.
+  workflow_call:
 
 permissions:
   contents: read
@@ -14,27 +14,22 @@ concurrency:
 
 jobs:
   check-version:
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}
-      should-publish: ${{ steps.check.outputs.should-publish }}
+      should_publish: ${{ steps.check.outputs.should_publish }}
 
     steps:
       - name: Checkout the CI-tested revision
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: Verify the tested revision is still main
         id: revision
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           if [ "$(git rev-parse HEAD)" != "$TESTED_SHA" ]; then
             echo "Checked out revision does not match the successful CI run" >&2
@@ -83,7 +78,7 @@ jobs:
 
   publish:
     needs: check-version
-    if: needs.check-version.outputs.should-publish == 'true'
+    if: needs.check-version.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -93,7 +88,7 @@ jobs:
       - name: Checkout the CI-tested revision
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1.17.0
@@ -124,7 +119,7 @@ jobs:
 
       - name: Reconfirm the published revision
         env:
-          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          TESTED_SHA: ${{ github.sha }}
         run: |
           git fetch --no-tags origin main
 
@@ -142,7 +137,7 @@ jobs:
       - publish
     if: >-
       needs.check-version.result == 'success' &&
-      needs.check-version.outputs.should-publish == 'true' &&
+      needs.check-version.outputs.should_publish == 'true' &&
       needs.publish.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -154,7 +149,7 @@ jobs:
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}
-          target_commitish: ${{ github.event.workflow_run.head_sha }}
+          target_commitish: ${{ github.sha }}
           draft: false
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
Replaces the detached `workflow_run` publisher with the reusable workflow called from the final CI job. Publishing now waits on `verify`, runs only for successful pushes to `main`, and fixes the `should_publish` output while retaining the stale-revision and version guards.